### PR TITLE
Fix python38 migrator

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -22,6 +22,10 @@ jobs:
         CONFIG: linux_mpimpichpython3.7
         UPLOAD_PACKAGES: True
         DOCKER_IMAGE: condaforge/linux-anvil-comp7
+      linux_mpimpichpython3.8:
+        CONFIG: linux_mpimpichpython3.8
+        UPLOAD_PACKAGES: True
+        DOCKER_IMAGE: condaforge/linux-anvil-comp7
       linux_mpiopenmpipython2.7:
         CONFIG: linux_mpiopenmpipython2.7
         UPLOAD_PACKAGES: True
@@ -32,6 +36,10 @@ jobs:
         DOCKER_IMAGE: condaforge/linux-anvil-comp7
       linux_mpiopenmpipython3.7:
         CONFIG: linux_mpiopenmpipython3.7
+        UPLOAD_PACKAGES: True
+        DOCKER_IMAGE: condaforge/linux-anvil-comp7
+      linux_mpiopenmpipython3.8:
+        CONFIG: linux_mpiopenmpipython3.8
         UPLOAD_PACKAGES: True
         DOCKER_IMAGE: condaforge/linux-anvil-comp7
   steps:

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -19,6 +19,9 @@ jobs:
       osx_mpimpichpython3.7:
         CONFIG: osx_mpimpichpython3.7
         UPLOAD_PACKAGES: True
+      osx_mpimpichpython3.8:
+        CONFIG: osx_mpimpichpython3.8
+        UPLOAD_PACKAGES: True
       osx_mpiopenmpipython2.7:
         CONFIG: osx_mpiopenmpipython2.7
         UPLOAD_PACKAGES: True
@@ -27,6 +30,9 @@ jobs:
         UPLOAD_PACKAGES: True
       osx_mpiopenmpipython3.7:
         CONFIG: osx_mpiopenmpipython3.7
+        UPLOAD_PACKAGES: True
+      osx_mpiopenmpipython3.8:
+        CONFIG: osx_mpiopenmpipython3.8
         UPLOAD_PACKAGES: True
 
   steps:

--- a/.ci_support/linux_mpimpichpython3.8.yaml
+++ b/.ci_support/linux_mpimpichpython3.8.yaml
@@ -1,0 +1,20 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '7'
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+docker_image:
+- condaforge/linux-anvil-comp7
+mpi:
+- mpich
+numpy:
+- '1.14'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- '3.8'

--- a/.ci_support/linux_mpiopenmpipython3.8.yaml
+++ b/.ci_support/linux_mpiopenmpipython3.8.yaml
@@ -1,0 +1,20 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '7'
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+docker_image:
+- condaforge/linux-anvil-comp7
+mpi:
+- openmpi
+numpy:
+- '1.14'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- '3.8'

--- a/.ci_support/migrations/python38.yaml
+++ b/.ci_support/migrations/python38.yaml
@@ -1,4 +1,55 @@
-bump_number: 0
-exclude: [c_compiler, vc, cxx_compiler]
-kind: version
-migration_number: 1
+migrator_ts: 1569538102   # The timestamp of when the migration was made
+__migrator:
+  kind:
+    version
+  exclude:
+    - c_compiler
+    - vc
+    - cxx_compiler
+  migration_number:  # Only use this if the bot messes up, putting this in will cause a complete rerun of the migration
+    1
+  bump_number: 0
+
+python:
+  - 2.7
+  - 3.6
+  - 3.7
+  - 3.8
+
+c_compiler:
+  # legacy compilers for things that refuse to move
+  - toolchain_c                # [(linux64 or osx) and (environ.get('CF_COMPILER_STACK') == 'comp4')]
+  # modern compilers
+  - gcc                        # [linux64]
+  - clang                      # [osx]
+  # non-standard arches get built with gcc
+  - gcc                        # [aarch64]
+  - gcc                        # [ppc64le]
+  - gcc                        # [armv7l]
+
+  - vs2008                     # [win]
+  - vs2015                     # [win]
+  - vs2015                     # [win]
+  - vs2015                     # [win]
+
+cxx_compiler:
+  # legacy compilers for things that refuse to move
+  - toolchain_cxx              # [(linux64 or osx) and (environ.get('CF_COMPILER_STACK') == 'comp4')]
+  # modern compilers
+  - gxx                        # [linux64]
+  - clangxx                    # [osx]
+
+  - gxx                        # [aarch64]
+  - gxx                        # [ppc64le]
+  - gxx                        # [armv7l]
+
+  - vs2008                     # [win]
+  - vs2015                     # [win]
+  - vs2015                     # [win]
+  - vs2015                     # [win]
+
+vc:                    # [win]
+  - 9                  # [win]
+  - 14                 # [win]
+  - 14                 # [win]
+  - 14                 # [win]

--- a/.ci_support/osx_mpimpichpython3.8.yaml
+++ b/.ci_support/osx_mpimpichpython3.8.yaml
@@ -1,0 +1,24 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+c_compiler:
+- clang
+c_compiler_version:
+- '9'
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+macos_machine:
+- x86_64-apple-darwin13.4.0
+macos_min_version:
+- '10.9'
+mpi:
+- mpich
+numpy:
+- '1.14'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- '3.8'

--- a/.ci_support/osx_mpiopenmpipython3.8.yaml
+++ b/.ci_support/osx_mpiopenmpipython3.8.yaml
@@ -1,0 +1,24 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+c_compiler:
+- clang
+c_compiler_version:
+- '9'
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+macos_machine:
+- x86_64-apple-darwin13.4.0
+macos_min_version:
+- '10.9'
+mpi:
+- openmpi
+numpy:
+- '1.14'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- '3.8'

--- a/README.md
+++ b/README.md
@@ -50,6 +50,13 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>linux_mpimpichpython3.8</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5831&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/slepc4py-feedstock?branchName=master&jobName=linux&configuration=linux_mpimpichpython3.8" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>linux_mpiopenmpipython2.7</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5831&branchName=master">
@@ -68,6 +75,13 @@ Current build status
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5831&branchName=master">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/slepc4py-feedstock?branchName=master&jobName=linux&configuration=linux_mpiopenmpipython3.7" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_mpiopenmpipython3.8</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5831&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/slepc4py-feedstock?branchName=master&jobName=linux&configuration=linux_mpiopenmpipython3.8" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -92,6 +106,13 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>osx_mpimpichpython3.8</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5831&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/slepc4py-feedstock?branchName=master&jobName=osx&configuration=osx_mpimpichpython3.8" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>osx_mpiopenmpipython2.7</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5831&branchName=master">
@@ -110,6 +131,13 @@ Current build status
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5831&branchName=master">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/slepc4py-feedstock?branchName=master&jobName=osx&configuration=osx_mpiopenmpipython3.7" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_mpiopenmpipython3.8</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5831&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/slepc4py-feedstock?branchName=master&jobName=osx&configuration=osx_mpiopenmpipython3.8" alt="variant">
                 </a>
               </td>
             </tr>
@@ -175,7 +203,7 @@ A feedstock is made up of a conda recipe (the instructions on what and how to bu
 the package) and the necessary configurations for automatic building using freely
 available continuous integration services. Thanks to the awesome service provided by
 [CircleCI](https://circleci.com/), [AppVeyor](https://www.appveyor.com/)
-and [TravisCI](https://travis-ci.org/) it is possible to build and upload installable
+and [TravisCI](https://travis-ci.com/) it is possible to build and upload installable
 packages to the [conda-forge](https://anaconda.org/conda-forge)
 [Anaconda-Cloud](https://anaconda.org/) channel for Linux, Windows and OSX respectively.
 


### PR DESCRIPTION
the migrator in #11 didn't actually enable python38, presumably why the `bot-rerun` label was added