### PR TITLE
Rebuild for openmpi 5

### DIFF
--- a/.ci_support/linux_64_devicecuda11mpimpichnumpy1.22python3.10.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_64_devicecuda11mpimpichnumpy1.22python3.10.____cpythonscalarcomplex.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_64_devicecuda11mpimpichnumpy1.22python3.10.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_64_devicecuda11mpimpichnumpy1.22python3.10.____cpythonscalarreal.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_64_devicecuda11mpimpichnumpy1.22python3.8.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_64_devicecuda11mpimpichnumpy1.22python3.8.____cpythonscalarcomplex.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_64_devicecuda11mpimpichnumpy1.22python3.8.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_64_devicecuda11mpimpichnumpy1.22python3.8.____cpythonscalarreal.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_64_devicecuda11mpimpichnumpy1.22python3.9.____73_pypyscalarcomplex.yaml
+++ b/.ci_support/linux_64_devicecuda11mpimpichnumpy1.22python3.9.____73_pypyscalarcomplex.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_64_devicecuda11mpimpichnumpy1.22python3.9.____73_pypyscalarreal.yaml
+++ b/.ci_support/linux_64_devicecuda11mpimpichnumpy1.22python3.9.____73_pypyscalarreal.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_64_devicecuda11mpimpichnumpy1.22python3.9.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_64_devicecuda11mpimpichnumpy1.22python3.9.____cpythonscalarcomplex.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_64_devicecuda11mpimpichnumpy1.22python3.9.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_64_devicecuda11mpimpichnumpy1.22python3.9.____cpythonscalarreal.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_64_devicecuda11mpimpichnumpy1.23python3.11.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_64_devicecuda11mpimpichnumpy1.23python3.11.____cpythonscalarcomplex.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.23'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_64_devicecuda11mpimpichnumpy1.23python3.11.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_64_devicecuda11mpimpichnumpy1.23python3.11.____cpythonscalarreal.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.23'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_64_devicecuda11mpimpichnumpy1.26python3.12.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_64_devicecuda11mpimpichnumpy1.26python3.12.____cpythonscalarcomplex.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.26'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_64_devicecuda11mpimpichnumpy1.26python3.12.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_64_devicecuda11mpimpichnumpy1.26python3.12.____cpythonscalarreal.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.26'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_64_devicecuda11mpiopenmpinumpy1.22python3.10.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_64_devicecuda11mpiopenmpinumpy1.22python3.10.____cpythonscalarcomplex.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_64_devicecuda11mpiopenmpinumpy1.22python3.10.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_64_devicecuda11mpiopenmpinumpy1.22python3.10.____cpythonscalarreal.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_64_devicecuda11mpiopenmpinumpy1.22python3.8.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_64_devicecuda11mpiopenmpinumpy1.22python3.8.____cpythonscalarcomplex.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_64_devicecuda11mpiopenmpinumpy1.22python3.8.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_64_devicecuda11mpiopenmpinumpy1.22python3.8.____cpythonscalarreal.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_64_devicecuda11mpiopenmpinumpy1.22python3.9.____73_pypyscalarcomplex.yaml
+++ b/.ci_support/linux_64_devicecuda11mpiopenmpinumpy1.22python3.9.____73_pypyscalarcomplex.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_64_devicecuda11mpiopenmpinumpy1.22python3.9.____73_pypyscalarreal.yaml
+++ b/.ci_support/linux_64_devicecuda11mpiopenmpinumpy1.22python3.9.____73_pypyscalarreal.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_64_devicecuda11mpiopenmpinumpy1.22python3.9.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_64_devicecuda11mpiopenmpinumpy1.22python3.9.____cpythonscalarcomplex.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_64_devicecuda11mpiopenmpinumpy1.22python3.9.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_64_devicecuda11mpiopenmpinumpy1.22python3.9.____cpythonscalarreal.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_64_devicecuda11mpiopenmpinumpy1.23python3.11.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_64_devicecuda11mpiopenmpinumpy1.23python3.11.____cpythonscalarcomplex.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.23'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_64_devicecuda11mpiopenmpinumpy1.23python3.11.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_64_devicecuda11mpiopenmpinumpy1.23python3.11.____cpythonscalarreal.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.23'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_64_devicecuda11mpiopenmpinumpy1.26python3.12.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_64_devicecuda11mpiopenmpinumpy1.26python3.12.____cpythonscalarcomplex.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.26'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_64_devicecuda11mpiopenmpinumpy1.26python3.12.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_64_devicecuda11mpiopenmpinumpy1.26python3.12.____cpythonscalarreal.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.26'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_64_devicecuda12mpimpichnumpy1.22python3.10.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_64_devicecuda12mpimpichnumpy1.22python3.10.____cpythonscalarcomplex.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_64_devicecuda12mpimpichnumpy1.22python3.10.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_64_devicecuda12mpimpichnumpy1.22python3.10.____cpythonscalarreal.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_64_devicecuda12mpimpichnumpy1.22python3.8.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_64_devicecuda12mpimpichnumpy1.22python3.8.____cpythonscalarcomplex.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_64_devicecuda12mpimpichnumpy1.22python3.8.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_64_devicecuda12mpimpichnumpy1.22python3.8.____cpythonscalarreal.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_64_devicecuda12mpimpichnumpy1.22python3.9.____73_pypyscalarcomplex.yaml
+++ b/.ci_support/linux_64_devicecuda12mpimpichnumpy1.22python3.9.____73_pypyscalarcomplex.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_64_devicecuda12mpimpichnumpy1.22python3.9.____73_pypyscalarreal.yaml
+++ b/.ci_support/linux_64_devicecuda12mpimpichnumpy1.22python3.9.____73_pypyscalarreal.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_64_devicecuda12mpimpichnumpy1.22python3.9.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_64_devicecuda12mpimpichnumpy1.22python3.9.____cpythonscalarcomplex.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_64_devicecuda12mpimpichnumpy1.22python3.9.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_64_devicecuda12mpimpichnumpy1.22python3.9.____cpythonscalarreal.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_64_devicecuda12mpimpichnumpy1.23python3.11.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_64_devicecuda12mpimpichnumpy1.23python3.11.____cpythonscalarcomplex.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.23'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_64_devicecuda12mpimpichnumpy1.23python3.11.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_64_devicecuda12mpimpichnumpy1.23python3.11.____cpythonscalarreal.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.23'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_64_devicecuda12mpimpichnumpy1.26python3.12.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_64_devicecuda12mpimpichnumpy1.26python3.12.____cpythonscalarcomplex.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.26'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_64_devicecuda12mpimpichnumpy1.26python3.12.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_64_devicecuda12mpimpichnumpy1.26python3.12.____cpythonscalarreal.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.26'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_64_devicecuda12mpiopenmpinumpy1.22python3.10.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_64_devicecuda12mpiopenmpinumpy1.22python3.10.____cpythonscalarcomplex.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_64_devicecuda12mpiopenmpinumpy1.22python3.10.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_64_devicecuda12mpiopenmpinumpy1.22python3.10.____cpythonscalarreal.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_64_devicecuda12mpiopenmpinumpy1.22python3.8.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_64_devicecuda12mpiopenmpinumpy1.22python3.8.____cpythonscalarcomplex.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_64_devicecuda12mpiopenmpinumpy1.22python3.8.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_64_devicecuda12mpiopenmpinumpy1.22python3.8.____cpythonscalarreal.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_64_devicecuda12mpiopenmpinumpy1.22python3.9.____73_pypyscalarcomplex.yaml
+++ b/.ci_support/linux_64_devicecuda12mpiopenmpinumpy1.22python3.9.____73_pypyscalarcomplex.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_64_devicecuda12mpiopenmpinumpy1.22python3.9.____73_pypyscalarreal.yaml
+++ b/.ci_support/linux_64_devicecuda12mpiopenmpinumpy1.22python3.9.____73_pypyscalarreal.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_64_devicecuda12mpiopenmpinumpy1.22python3.9.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_64_devicecuda12mpiopenmpinumpy1.22python3.9.____cpythonscalarcomplex.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_64_devicecuda12mpiopenmpinumpy1.22python3.9.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_64_devicecuda12mpiopenmpinumpy1.22python3.9.____cpythonscalarreal.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_64_devicecuda12mpiopenmpinumpy1.23python3.11.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_64_devicecuda12mpiopenmpinumpy1.23python3.11.____cpythonscalarcomplex.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.23'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_64_devicecuda12mpiopenmpinumpy1.23python3.11.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_64_devicecuda12mpiopenmpinumpy1.23python3.11.____cpythonscalarreal.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.23'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_64_devicecuda12mpiopenmpinumpy1.26python3.12.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_64_devicecuda12mpiopenmpinumpy1.26python3.12.____cpythonscalarcomplex.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.26'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_64_devicecuda12mpiopenmpinumpy1.26python3.12.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_64_devicecuda12mpiopenmpinumpy1.26python3.12.____cpythonscalarreal.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.26'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_64_devicehostmpimpichnumpy1.22python3.10.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_64_devicehostmpimpichnumpy1.22python3.10.____cpythonscalarcomplex.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_64_devicehostmpimpichnumpy1.22python3.10.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_64_devicehostmpimpichnumpy1.22python3.10.____cpythonscalarreal.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_64_devicehostmpimpichnumpy1.22python3.8.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_64_devicehostmpimpichnumpy1.22python3.8.____cpythonscalarcomplex.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_64_devicehostmpimpichnumpy1.22python3.8.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_64_devicehostmpimpichnumpy1.22python3.8.____cpythonscalarreal.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_64_devicehostmpimpichnumpy1.22python3.9.____73_pypyscalarcomplex.yaml
+++ b/.ci_support/linux_64_devicehostmpimpichnumpy1.22python3.9.____73_pypyscalarcomplex.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_64_devicehostmpimpichnumpy1.22python3.9.____73_pypyscalarreal.yaml
+++ b/.ci_support/linux_64_devicehostmpimpichnumpy1.22python3.9.____73_pypyscalarreal.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_64_devicehostmpimpichnumpy1.22python3.9.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_64_devicehostmpimpichnumpy1.22python3.9.____cpythonscalarcomplex.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_64_devicehostmpimpichnumpy1.22python3.9.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_64_devicehostmpimpichnumpy1.22python3.9.____cpythonscalarreal.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_64_devicehostmpimpichnumpy1.23python3.11.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_64_devicehostmpimpichnumpy1.23python3.11.____cpythonscalarcomplex.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.23'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_64_devicehostmpimpichnumpy1.23python3.11.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_64_devicehostmpimpichnumpy1.23python3.11.____cpythonscalarreal.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.23'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_64_devicehostmpimpichnumpy1.26python3.12.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_64_devicehostmpimpichnumpy1.26python3.12.____cpythonscalarcomplex.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.26'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_64_devicehostmpimpichnumpy1.26python3.12.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_64_devicehostmpimpichnumpy1.26python3.12.____cpythonscalarreal.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.26'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_64_devicehostmpiopenmpinumpy1.22python3.10.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_64_devicehostmpiopenmpinumpy1.22python3.10.____cpythonscalarcomplex.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_64_devicehostmpiopenmpinumpy1.22python3.10.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_64_devicehostmpiopenmpinumpy1.22python3.10.____cpythonscalarreal.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_64_devicehostmpiopenmpinumpy1.22python3.8.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_64_devicehostmpiopenmpinumpy1.22python3.8.____cpythonscalarcomplex.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_64_devicehostmpiopenmpinumpy1.22python3.8.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_64_devicehostmpiopenmpinumpy1.22python3.8.____cpythonscalarreal.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_64_devicehostmpiopenmpinumpy1.22python3.9.____73_pypyscalarcomplex.yaml
+++ b/.ci_support/linux_64_devicehostmpiopenmpinumpy1.22python3.9.____73_pypyscalarcomplex.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_64_devicehostmpiopenmpinumpy1.22python3.9.____73_pypyscalarreal.yaml
+++ b/.ci_support/linux_64_devicehostmpiopenmpinumpy1.22python3.9.____73_pypyscalarreal.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_64_devicehostmpiopenmpinumpy1.22python3.9.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_64_devicehostmpiopenmpinumpy1.22python3.9.____cpythonscalarcomplex.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_64_devicehostmpiopenmpinumpy1.22python3.9.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_64_devicehostmpiopenmpinumpy1.22python3.9.____cpythonscalarreal.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_64_devicehostmpiopenmpinumpy1.23python3.11.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_64_devicehostmpiopenmpinumpy1.23python3.11.____cpythonscalarcomplex.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.23'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_64_devicehostmpiopenmpinumpy1.23python3.11.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_64_devicehostmpiopenmpinumpy1.23python3.11.____cpythonscalarreal.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.23'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_64_devicehostmpiopenmpinumpy1.26python3.12.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_64_devicehostmpiopenmpinumpy1.26python3.12.____cpythonscalarcomplex.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.26'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_64_devicehostmpiopenmpinumpy1.26python3.12.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_64_devicehostmpiopenmpinumpy1.26python3.12.____cpythonscalarreal.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.26'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_devicecuda11mpimpichnumpy1.22python3.10.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_devicecuda11mpimpichnumpy1.22python3.10.____cpythonscalarcomplex.yaml
@@ -27,7 +27,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_devicecuda11mpimpichnumpy1.22python3.10.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_aarch64_devicecuda11mpimpichnumpy1.22python3.10.____cpythonscalarreal.yaml
@@ -27,7 +27,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_devicecuda11mpimpichnumpy1.22python3.8.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_devicecuda11mpimpichnumpy1.22python3.8.____cpythonscalarcomplex.yaml
@@ -27,7 +27,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_devicecuda11mpimpichnumpy1.22python3.8.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_aarch64_devicecuda11mpimpichnumpy1.22python3.8.____cpythonscalarreal.yaml
@@ -27,7 +27,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_devicecuda11mpimpichnumpy1.22python3.9.____73_pypyscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_devicecuda11mpimpichnumpy1.22python3.9.____73_pypyscalarcomplex.yaml
@@ -27,7 +27,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_devicecuda11mpimpichnumpy1.22python3.9.____73_pypyscalarreal.yaml
+++ b/.ci_support/linux_aarch64_devicecuda11mpimpichnumpy1.22python3.9.____73_pypyscalarreal.yaml
@@ -27,7 +27,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_devicecuda11mpimpichnumpy1.22python3.9.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_devicecuda11mpimpichnumpy1.22python3.9.____cpythonscalarcomplex.yaml
@@ -27,7 +27,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_devicecuda11mpimpichnumpy1.22python3.9.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_aarch64_devicecuda11mpimpichnumpy1.22python3.9.____cpythonscalarreal.yaml
@@ -27,7 +27,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_devicecuda11mpimpichnumpy1.23python3.11.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_devicecuda11mpimpichnumpy1.23python3.11.____cpythonscalarcomplex.yaml
@@ -27,7 +27,7 @@ mpich:
 numpy:
 - '1.23'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_devicecuda11mpimpichnumpy1.23python3.11.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_aarch64_devicecuda11mpimpichnumpy1.23python3.11.____cpythonscalarreal.yaml
@@ -27,7 +27,7 @@ mpich:
 numpy:
 - '1.23'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_devicecuda11mpimpichnumpy1.26python3.12.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_devicecuda11mpimpichnumpy1.26python3.12.____cpythonscalarcomplex.yaml
@@ -27,7 +27,7 @@ mpich:
 numpy:
 - '1.26'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_devicecuda11mpimpichnumpy1.26python3.12.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_aarch64_devicecuda11mpimpichnumpy1.26python3.12.____cpythonscalarreal.yaml
@@ -27,7 +27,7 @@ mpich:
 numpy:
 - '1.26'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_devicecuda11mpiopenmpinumpy1.22python3.10.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_devicecuda11mpiopenmpinumpy1.22python3.10.____cpythonscalarcomplex.yaml
@@ -27,7 +27,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_devicecuda11mpiopenmpinumpy1.22python3.10.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_aarch64_devicecuda11mpiopenmpinumpy1.22python3.10.____cpythonscalarreal.yaml
@@ -27,7 +27,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_devicecuda11mpiopenmpinumpy1.22python3.8.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_devicecuda11mpiopenmpinumpy1.22python3.8.____cpythonscalarcomplex.yaml
@@ -27,7 +27,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_devicecuda11mpiopenmpinumpy1.22python3.8.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_aarch64_devicecuda11mpiopenmpinumpy1.22python3.8.____cpythonscalarreal.yaml
@@ -27,7 +27,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_devicecuda11mpiopenmpinumpy1.22python3.9.____73_pypyscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_devicecuda11mpiopenmpinumpy1.22python3.9.____73_pypyscalarcomplex.yaml
@@ -27,7 +27,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_devicecuda11mpiopenmpinumpy1.22python3.9.____73_pypyscalarreal.yaml
+++ b/.ci_support/linux_aarch64_devicecuda11mpiopenmpinumpy1.22python3.9.____73_pypyscalarreal.yaml
@@ -27,7 +27,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_devicecuda11mpiopenmpinumpy1.22python3.9.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_devicecuda11mpiopenmpinumpy1.22python3.9.____cpythonscalarcomplex.yaml
@@ -27,7 +27,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_devicecuda11mpiopenmpinumpy1.22python3.9.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_aarch64_devicecuda11mpiopenmpinumpy1.22python3.9.____cpythonscalarreal.yaml
@@ -27,7 +27,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_devicecuda11mpiopenmpinumpy1.23python3.11.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_devicecuda11mpiopenmpinumpy1.23python3.11.____cpythonscalarcomplex.yaml
@@ -27,7 +27,7 @@ mpich:
 numpy:
 - '1.23'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_devicecuda11mpiopenmpinumpy1.23python3.11.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_aarch64_devicecuda11mpiopenmpinumpy1.23python3.11.____cpythonscalarreal.yaml
@@ -27,7 +27,7 @@ mpich:
 numpy:
 - '1.23'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_devicecuda11mpiopenmpinumpy1.26python3.12.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_devicecuda11mpiopenmpinumpy1.26python3.12.____cpythonscalarcomplex.yaml
@@ -27,7 +27,7 @@ mpich:
 numpy:
 - '1.26'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_devicecuda11mpiopenmpinumpy1.26python3.12.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_aarch64_devicecuda11mpiopenmpinumpy1.26python3.12.____cpythonscalarreal.yaml
@@ -27,7 +27,7 @@ mpich:
 numpy:
 - '1.26'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_devicecuda12mpimpichnumpy1.22python3.10.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_devicecuda12mpimpichnumpy1.22python3.10.____cpythonscalarcomplex.yaml
@@ -27,7 +27,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_devicecuda12mpimpichnumpy1.22python3.10.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_aarch64_devicecuda12mpimpichnumpy1.22python3.10.____cpythonscalarreal.yaml
@@ -27,7 +27,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_devicecuda12mpimpichnumpy1.22python3.8.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_devicecuda12mpimpichnumpy1.22python3.8.____cpythonscalarcomplex.yaml
@@ -27,7 +27,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_devicecuda12mpimpichnumpy1.22python3.8.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_aarch64_devicecuda12mpimpichnumpy1.22python3.8.____cpythonscalarreal.yaml
@@ -27,7 +27,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_devicecuda12mpimpichnumpy1.22python3.9.____73_pypyscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_devicecuda12mpimpichnumpy1.22python3.9.____73_pypyscalarcomplex.yaml
@@ -27,7 +27,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_devicecuda12mpimpichnumpy1.22python3.9.____73_pypyscalarreal.yaml
+++ b/.ci_support/linux_aarch64_devicecuda12mpimpichnumpy1.22python3.9.____73_pypyscalarreal.yaml
@@ -27,7 +27,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_devicecuda12mpimpichnumpy1.22python3.9.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_devicecuda12mpimpichnumpy1.22python3.9.____cpythonscalarcomplex.yaml
@@ -27,7 +27,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_devicecuda12mpimpichnumpy1.22python3.9.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_aarch64_devicecuda12mpimpichnumpy1.22python3.9.____cpythonscalarreal.yaml
@@ -27,7 +27,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_devicecuda12mpimpichnumpy1.23python3.11.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_devicecuda12mpimpichnumpy1.23python3.11.____cpythonscalarcomplex.yaml
@@ -27,7 +27,7 @@ mpich:
 numpy:
 - '1.23'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_devicecuda12mpimpichnumpy1.23python3.11.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_aarch64_devicecuda12mpimpichnumpy1.23python3.11.____cpythonscalarreal.yaml
@@ -27,7 +27,7 @@ mpich:
 numpy:
 - '1.23'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_devicecuda12mpimpichnumpy1.26python3.12.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_devicecuda12mpimpichnumpy1.26python3.12.____cpythonscalarcomplex.yaml
@@ -27,7 +27,7 @@ mpich:
 numpy:
 - '1.26'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_devicecuda12mpimpichnumpy1.26python3.12.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_aarch64_devicecuda12mpimpichnumpy1.26python3.12.____cpythonscalarreal.yaml
@@ -27,7 +27,7 @@ mpich:
 numpy:
 - '1.26'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_devicecuda12mpiopenmpinumpy1.22python3.10.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_devicecuda12mpiopenmpinumpy1.22python3.10.____cpythonscalarcomplex.yaml
@@ -27,7 +27,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_devicecuda12mpiopenmpinumpy1.22python3.10.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_aarch64_devicecuda12mpiopenmpinumpy1.22python3.10.____cpythonscalarreal.yaml
@@ -27,7 +27,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_devicecuda12mpiopenmpinumpy1.22python3.8.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_devicecuda12mpiopenmpinumpy1.22python3.8.____cpythonscalarcomplex.yaml
@@ -27,7 +27,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_devicecuda12mpiopenmpinumpy1.22python3.8.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_aarch64_devicecuda12mpiopenmpinumpy1.22python3.8.____cpythonscalarreal.yaml
@@ -27,7 +27,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_devicecuda12mpiopenmpinumpy1.22python3.9.____73_pypyscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_devicecuda12mpiopenmpinumpy1.22python3.9.____73_pypyscalarcomplex.yaml
@@ -27,7 +27,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_devicecuda12mpiopenmpinumpy1.22python3.9.____73_pypyscalarreal.yaml
+++ b/.ci_support/linux_aarch64_devicecuda12mpiopenmpinumpy1.22python3.9.____73_pypyscalarreal.yaml
@@ -27,7 +27,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_devicecuda12mpiopenmpinumpy1.22python3.9.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_devicecuda12mpiopenmpinumpy1.22python3.9.____cpythonscalarcomplex.yaml
@@ -27,7 +27,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_devicecuda12mpiopenmpinumpy1.22python3.9.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_aarch64_devicecuda12mpiopenmpinumpy1.22python3.9.____cpythonscalarreal.yaml
@@ -27,7 +27,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_devicecuda12mpiopenmpinumpy1.23python3.11.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_devicecuda12mpiopenmpinumpy1.23python3.11.____cpythonscalarcomplex.yaml
@@ -27,7 +27,7 @@ mpich:
 numpy:
 - '1.23'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_devicecuda12mpiopenmpinumpy1.23python3.11.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_aarch64_devicecuda12mpiopenmpinumpy1.23python3.11.____cpythonscalarreal.yaml
@@ -27,7 +27,7 @@ mpich:
 numpy:
 - '1.23'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_devicecuda12mpiopenmpinumpy1.26python3.12.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_devicecuda12mpiopenmpinumpy1.26python3.12.____cpythonscalarcomplex.yaml
@@ -27,7 +27,7 @@ mpich:
 numpy:
 - '1.26'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_devicecuda12mpiopenmpinumpy1.26python3.12.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_aarch64_devicecuda12mpiopenmpinumpy1.26python3.12.____cpythonscalarreal.yaml
@@ -27,7 +27,7 @@ mpich:
 numpy:
 - '1.26'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_devicehostmpimpichnumpy1.22python3.10.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_devicehostmpimpichnumpy1.22python3.10.____cpythonscalarcomplex.yaml
@@ -27,7 +27,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_devicehostmpimpichnumpy1.22python3.10.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_aarch64_devicehostmpimpichnumpy1.22python3.10.____cpythonscalarreal.yaml
@@ -27,7 +27,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_devicehostmpimpichnumpy1.22python3.8.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_devicehostmpimpichnumpy1.22python3.8.____cpythonscalarcomplex.yaml
@@ -27,7 +27,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_devicehostmpimpichnumpy1.22python3.8.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_aarch64_devicehostmpimpichnumpy1.22python3.8.____cpythonscalarreal.yaml
@@ -27,7 +27,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_devicehostmpimpichnumpy1.22python3.9.____73_pypyscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_devicehostmpimpichnumpy1.22python3.9.____73_pypyscalarcomplex.yaml
@@ -27,7 +27,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_devicehostmpimpichnumpy1.22python3.9.____73_pypyscalarreal.yaml
+++ b/.ci_support/linux_aarch64_devicehostmpimpichnumpy1.22python3.9.____73_pypyscalarreal.yaml
@@ -27,7 +27,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_devicehostmpimpichnumpy1.22python3.9.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_devicehostmpimpichnumpy1.22python3.9.____cpythonscalarcomplex.yaml
@@ -27,7 +27,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_devicehostmpimpichnumpy1.22python3.9.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_aarch64_devicehostmpimpichnumpy1.22python3.9.____cpythonscalarreal.yaml
@@ -27,7 +27,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_devicehostmpimpichnumpy1.23python3.11.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_devicehostmpimpichnumpy1.23python3.11.____cpythonscalarcomplex.yaml
@@ -27,7 +27,7 @@ mpich:
 numpy:
 - '1.23'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_devicehostmpimpichnumpy1.23python3.11.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_aarch64_devicehostmpimpichnumpy1.23python3.11.____cpythonscalarreal.yaml
@@ -27,7 +27,7 @@ mpich:
 numpy:
 - '1.23'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_devicehostmpimpichnumpy1.26python3.12.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_devicehostmpimpichnumpy1.26python3.12.____cpythonscalarcomplex.yaml
@@ -27,7 +27,7 @@ mpich:
 numpy:
 - '1.26'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_devicehostmpimpichnumpy1.26python3.12.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_aarch64_devicehostmpimpichnumpy1.26python3.12.____cpythonscalarreal.yaml
@@ -27,7 +27,7 @@ mpich:
 numpy:
 - '1.26'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_devicehostmpiopenmpinumpy1.22python3.10.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_devicehostmpiopenmpinumpy1.22python3.10.____cpythonscalarcomplex.yaml
@@ -27,7 +27,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_devicehostmpiopenmpinumpy1.22python3.10.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_aarch64_devicehostmpiopenmpinumpy1.22python3.10.____cpythonscalarreal.yaml
@@ -27,7 +27,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_devicehostmpiopenmpinumpy1.22python3.8.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_devicehostmpiopenmpinumpy1.22python3.8.____cpythonscalarcomplex.yaml
@@ -27,7 +27,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_devicehostmpiopenmpinumpy1.22python3.8.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_aarch64_devicehostmpiopenmpinumpy1.22python3.8.____cpythonscalarreal.yaml
@@ -27,7 +27,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_devicehostmpiopenmpinumpy1.22python3.9.____73_pypyscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_devicehostmpiopenmpinumpy1.22python3.9.____73_pypyscalarcomplex.yaml
@@ -27,7 +27,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_devicehostmpiopenmpinumpy1.22python3.9.____73_pypyscalarreal.yaml
+++ b/.ci_support/linux_aarch64_devicehostmpiopenmpinumpy1.22python3.9.____73_pypyscalarreal.yaml
@@ -27,7 +27,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_devicehostmpiopenmpinumpy1.22python3.9.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_devicehostmpiopenmpinumpy1.22python3.9.____cpythonscalarcomplex.yaml
@@ -27,7 +27,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_devicehostmpiopenmpinumpy1.22python3.9.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_aarch64_devicehostmpiopenmpinumpy1.22python3.9.____cpythonscalarreal.yaml
@@ -27,7 +27,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_devicehostmpiopenmpinumpy1.23python3.11.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_devicehostmpiopenmpinumpy1.23python3.11.____cpythonscalarcomplex.yaml
@@ -27,7 +27,7 @@ mpich:
 numpy:
 - '1.23'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_devicehostmpiopenmpinumpy1.23python3.11.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_aarch64_devicehostmpiopenmpinumpy1.23python3.11.____cpythonscalarreal.yaml
@@ -27,7 +27,7 @@ mpich:
 numpy:
 - '1.23'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_devicehostmpiopenmpinumpy1.26python3.12.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_devicehostmpiopenmpinumpy1.26python3.12.____cpythonscalarcomplex.yaml
@@ -27,7 +27,7 @@ mpich:
 numpy:
 - '1.26'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_devicehostmpiopenmpinumpy1.26python3.12.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_aarch64_devicehostmpiopenmpinumpy1.26python3.12.____cpythonscalarreal.yaml
@@ -27,7 +27,7 @@ mpich:
 numpy:
 - '1.26'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_devicecuda11mpimpichnumpy1.22python3.10.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_devicecuda11mpimpichnumpy1.22python3.10.____cpythonscalarcomplex.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_devicecuda11mpimpichnumpy1.22python3.10.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_devicecuda11mpimpichnumpy1.22python3.10.____cpythonscalarreal.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_devicecuda11mpimpichnumpy1.22python3.8.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_devicecuda11mpimpichnumpy1.22python3.8.____cpythonscalarcomplex.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_devicecuda11mpimpichnumpy1.22python3.8.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_devicecuda11mpimpichnumpy1.22python3.8.____cpythonscalarreal.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_devicecuda11mpimpichnumpy1.22python3.9.____73_pypyscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_devicecuda11mpimpichnumpy1.22python3.9.____73_pypyscalarcomplex.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_devicecuda11mpimpichnumpy1.22python3.9.____73_pypyscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_devicecuda11mpimpichnumpy1.22python3.9.____73_pypyscalarreal.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_devicecuda11mpimpichnumpy1.22python3.9.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_devicecuda11mpimpichnumpy1.22python3.9.____cpythonscalarcomplex.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_devicecuda11mpimpichnumpy1.22python3.9.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_devicecuda11mpimpichnumpy1.22python3.9.____cpythonscalarreal.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_devicecuda11mpimpichnumpy1.23python3.11.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_devicecuda11mpimpichnumpy1.23python3.11.____cpythonscalarcomplex.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.23'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_devicecuda11mpimpichnumpy1.23python3.11.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_devicecuda11mpimpichnumpy1.23python3.11.____cpythonscalarreal.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.23'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_devicecuda11mpimpichnumpy1.26python3.12.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_devicecuda11mpimpichnumpy1.26python3.12.____cpythonscalarcomplex.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.26'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_devicecuda11mpimpichnumpy1.26python3.12.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_devicecuda11mpimpichnumpy1.26python3.12.____cpythonscalarreal.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.26'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_devicecuda11mpiopenmpinumpy1.22python3.10.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_devicecuda11mpiopenmpinumpy1.22python3.10.____cpythonscalarcomplex.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_devicecuda11mpiopenmpinumpy1.22python3.10.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_devicecuda11mpiopenmpinumpy1.22python3.10.____cpythonscalarreal.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_devicecuda11mpiopenmpinumpy1.22python3.8.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_devicecuda11mpiopenmpinumpy1.22python3.8.____cpythonscalarcomplex.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_devicecuda11mpiopenmpinumpy1.22python3.8.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_devicecuda11mpiopenmpinumpy1.22python3.8.____cpythonscalarreal.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_devicecuda11mpiopenmpinumpy1.22python3.9.____73_pypyscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_devicecuda11mpiopenmpinumpy1.22python3.9.____73_pypyscalarcomplex.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_devicecuda11mpiopenmpinumpy1.22python3.9.____73_pypyscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_devicecuda11mpiopenmpinumpy1.22python3.9.____73_pypyscalarreal.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_devicecuda11mpiopenmpinumpy1.22python3.9.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_devicecuda11mpiopenmpinumpy1.22python3.9.____cpythonscalarcomplex.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_devicecuda11mpiopenmpinumpy1.22python3.9.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_devicecuda11mpiopenmpinumpy1.22python3.9.____cpythonscalarreal.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_devicecuda11mpiopenmpinumpy1.23python3.11.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_devicecuda11mpiopenmpinumpy1.23python3.11.____cpythonscalarcomplex.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.23'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_devicecuda11mpiopenmpinumpy1.23python3.11.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_devicecuda11mpiopenmpinumpy1.23python3.11.____cpythonscalarreal.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.23'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_devicecuda11mpiopenmpinumpy1.26python3.12.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_devicecuda11mpiopenmpinumpy1.26python3.12.____cpythonscalarcomplex.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.26'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_devicecuda11mpiopenmpinumpy1.26python3.12.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_devicecuda11mpiopenmpinumpy1.26python3.12.____cpythonscalarreal.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.26'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_devicecuda12mpimpichnumpy1.22python3.10.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_devicecuda12mpimpichnumpy1.22python3.10.____cpythonscalarcomplex.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_devicecuda12mpimpichnumpy1.22python3.10.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_devicecuda12mpimpichnumpy1.22python3.10.____cpythonscalarreal.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_devicecuda12mpimpichnumpy1.22python3.8.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_devicecuda12mpimpichnumpy1.22python3.8.____cpythonscalarcomplex.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_devicecuda12mpimpichnumpy1.22python3.8.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_devicecuda12mpimpichnumpy1.22python3.8.____cpythonscalarreal.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_devicecuda12mpimpichnumpy1.22python3.9.____73_pypyscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_devicecuda12mpimpichnumpy1.22python3.9.____73_pypyscalarcomplex.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_devicecuda12mpimpichnumpy1.22python3.9.____73_pypyscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_devicecuda12mpimpichnumpy1.22python3.9.____73_pypyscalarreal.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_devicecuda12mpimpichnumpy1.22python3.9.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_devicecuda12mpimpichnumpy1.22python3.9.____cpythonscalarcomplex.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_devicecuda12mpimpichnumpy1.22python3.9.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_devicecuda12mpimpichnumpy1.22python3.9.____cpythonscalarreal.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_devicecuda12mpimpichnumpy1.23python3.11.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_devicecuda12mpimpichnumpy1.23python3.11.____cpythonscalarcomplex.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.23'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_devicecuda12mpimpichnumpy1.23python3.11.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_devicecuda12mpimpichnumpy1.23python3.11.____cpythonscalarreal.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.23'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_devicecuda12mpimpichnumpy1.26python3.12.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_devicecuda12mpimpichnumpy1.26python3.12.____cpythonscalarcomplex.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.26'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_devicecuda12mpimpichnumpy1.26python3.12.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_devicecuda12mpimpichnumpy1.26python3.12.____cpythonscalarreal.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.26'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_devicecuda12mpiopenmpinumpy1.22python3.10.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_devicecuda12mpiopenmpinumpy1.22python3.10.____cpythonscalarcomplex.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_devicecuda12mpiopenmpinumpy1.22python3.10.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_devicecuda12mpiopenmpinumpy1.22python3.10.____cpythonscalarreal.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_devicecuda12mpiopenmpinumpy1.22python3.8.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_devicecuda12mpiopenmpinumpy1.22python3.8.____cpythonscalarcomplex.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_devicecuda12mpiopenmpinumpy1.22python3.8.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_devicecuda12mpiopenmpinumpy1.22python3.8.____cpythonscalarreal.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_devicecuda12mpiopenmpinumpy1.22python3.9.____73_pypyscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_devicecuda12mpiopenmpinumpy1.22python3.9.____73_pypyscalarcomplex.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_devicecuda12mpiopenmpinumpy1.22python3.9.____73_pypyscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_devicecuda12mpiopenmpinumpy1.22python3.9.____73_pypyscalarreal.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_devicecuda12mpiopenmpinumpy1.22python3.9.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_devicecuda12mpiopenmpinumpy1.22python3.9.____cpythonscalarcomplex.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_devicecuda12mpiopenmpinumpy1.22python3.9.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_devicecuda12mpiopenmpinumpy1.22python3.9.____cpythonscalarreal.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_devicecuda12mpiopenmpinumpy1.23python3.11.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_devicecuda12mpiopenmpinumpy1.23python3.11.____cpythonscalarcomplex.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.23'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_devicecuda12mpiopenmpinumpy1.23python3.11.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_devicecuda12mpiopenmpinumpy1.23python3.11.____cpythonscalarreal.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.23'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_devicecuda12mpiopenmpinumpy1.26python3.12.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_devicecuda12mpiopenmpinumpy1.26python3.12.____cpythonscalarcomplex.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.26'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_devicecuda12mpiopenmpinumpy1.26python3.12.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_devicecuda12mpiopenmpinumpy1.26python3.12.____cpythonscalarreal.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.26'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_devicehostmpimpichnumpy1.22python3.10.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_devicehostmpimpichnumpy1.22python3.10.____cpythonscalarcomplex.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_devicehostmpimpichnumpy1.22python3.10.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_devicehostmpimpichnumpy1.22python3.10.____cpythonscalarreal.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_devicehostmpimpichnumpy1.22python3.8.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_devicehostmpimpichnumpy1.22python3.8.____cpythonscalarcomplex.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_devicehostmpimpichnumpy1.22python3.8.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_devicehostmpimpichnumpy1.22python3.8.____cpythonscalarreal.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_devicehostmpimpichnumpy1.22python3.9.____73_pypyscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_devicehostmpimpichnumpy1.22python3.9.____73_pypyscalarcomplex.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_devicehostmpimpichnumpy1.22python3.9.____73_pypyscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_devicehostmpimpichnumpy1.22python3.9.____73_pypyscalarreal.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_devicehostmpimpichnumpy1.22python3.9.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_devicehostmpimpichnumpy1.22python3.9.____cpythonscalarcomplex.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_devicehostmpimpichnumpy1.22python3.9.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_devicehostmpimpichnumpy1.22python3.9.____cpythonscalarreal.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_devicehostmpimpichnumpy1.23python3.11.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_devicehostmpimpichnumpy1.23python3.11.____cpythonscalarcomplex.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.23'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_devicehostmpimpichnumpy1.23python3.11.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_devicehostmpimpichnumpy1.23python3.11.____cpythonscalarreal.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.23'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_devicehostmpimpichnumpy1.26python3.12.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_devicehostmpimpichnumpy1.26python3.12.____cpythonscalarcomplex.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.26'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_devicehostmpimpichnumpy1.26python3.12.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_devicehostmpimpichnumpy1.26python3.12.____cpythonscalarreal.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.26'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_devicehostmpiopenmpinumpy1.22python3.10.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_devicehostmpiopenmpinumpy1.22python3.10.____cpythonscalarcomplex.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_devicehostmpiopenmpinumpy1.22python3.10.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_devicehostmpiopenmpinumpy1.22python3.10.____cpythonscalarreal.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_devicehostmpiopenmpinumpy1.22python3.8.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_devicehostmpiopenmpinumpy1.22python3.8.____cpythonscalarcomplex.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_devicehostmpiopenmpinumpy1.22python3.8.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_devicehostmpiopenmpinumpy1.22python3.8.____cpythonscalarreal.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_devicehostmpiopenmpinumpy1.22python3.9.____73_pypyscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_devicehostmpiopenmpinumpy1.22python3.9.____73_pypyscalarcomplex.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_devicehostmpiopenmpinumpy1.22python3.9.____73_pypyscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_devicehostmpiopenmpinumpy1.22python3.9.____73_pypyscalarreal.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_devicehostmpiopenmpinumpy1.22python3.9.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_devicehostmpiopenmpinumpy1.22python3.9.____cpythonscalarcomplex.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_devicehostmpiopenmpinumpy1.22python3.9.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_devicehostmpiopenmpinumpy1.22python3.9.____cpythonscalarreal.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_devicehostmpiopenmpinumpy1.23python3.11.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_devicehostmpiopenmpinumpy1.23python3.11.____cpythonscalarcomplex.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.23'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_devicehostmpiopenmpinumpy1.23python3.11.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_devicehostmpiopenmpinumpy1.23python3.11.____cpythonscalarreal.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.23'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_devicehostmpiopenmpinumpy1.26python3.12.____cpythonscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_devicehostmpiopenmpinumpy1.26python3.12.____cpythonscalarcomplex.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.26'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_devicehostmpiopenmpinumpy1.26python3.12.____cpythonscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_devicehostmpiopenmpinumpy1.26python3.12.____cpythonscalarreal.yaml
@@ -23,7 +23,7 @@ mpich:
 numpy:
 - '1.26'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/migrations/openmpi5.yaml
+++ b/.ci_support/migrations/openmpi5.yaml
@@ -1,0 +1,8 @@
+__migrator:
+  build_number: 1
+  commit_message: Rebuild for openmpi 5
+  kind: version
+  migration_number: 1
+migrator_ts: 1703196161.1453235
+openmpi:
+- '5'

--- a/.ci_support/osx_64_mpimpichnumpy1.22python3.10.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_64_mpimpichnumpy1.22python3.10.____cpythonscalarcomplex.yaml
@@ -25,7 +25,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/osx_64_mpimpichnumpy1.22python3.10.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_64_mpimpichnumpy1.22python3.10.____cpythonscalarreal.yaml
@@ -25,7 +25,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/osx_64_mpimpichnumpy1.22python3.8.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_64_mpimpichnumpy1.22python3.8.____cpythonscalarcomplex.yaml
@@ -25,7 +25,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/osx_64_mpimpichnumpy1.22python3.8.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_64_mpimpichnumpy1.22python3.8.____cpythonscalarreal.yaml
@@ -25,7 +25,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/osx_64_mpimpichnumpy1.22python3.9.____73_pypyscalarcomplex.yaml
+++ b/.ci_support/osx_64_mpimpichnumpy1.22python3.9.____73_pypyscalarcomplex.yaml
@@ -25,7 +25,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/osx_64_mpimpichnumpy1.22python3.9.____73_pypyscalarreal.yaml
+++ b/.ci_support/osx_64_mpimpichnumpy1.22python3.9.____73_pypyscalarreal.yaml
@@ -25,7 +25,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/osx_64_mpimpichnumpy1.22python3.9.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_64_mpimpichnumpy1.22python3.9.____cpythonscalarcomplex.yaml
@@ -25,7 +25,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/osx_64_mpimpichnumpy1.22python3.9.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_64_mpimpichnumpy1.22python3.9.____cpythonscalarreal.yaml
@@ -25,7 +25,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/osx_64_mpimpichnumpy1.23python3.11.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_64_mpimpichnumpy1.23python3.11.____cpythonscalarcomplex.yaml
@@ -25,7 +25,7 @@ mpich:
 numpy:
 - '1.23'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/osx_64_mpimpichnumpy1.23python3.11.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_64_mpimpichnumpy1.23python3.11.____cpythonscalarreal.yaml
@@ -25,7 +25,7 @@ mpich:
 numpy:
 - '1.23'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/osx_64_mpimpichnumpy1.26python3.12.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_64_mpimpichnumpy1.26python3.12.____cpythonscalarcomplex.yaml
@@ -25,7 +25,7 @@ mpich:
 numpy:
 - '1.26'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/osx_64_mpimpichnumpy1.26python3.12.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_64_mpimpichnumpy1.26python3.12.____cpythonscalarreal.yaml
@@ -25,7 +25,7 @@ mpich:
 numpy:
 - '1.26'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/osx_64_mpiopenmpinumpy1.22python3.10.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_64_mpiopenmpinumpy1.22python3.10.____cpythonscalarcomplex.yaml
@@ -25,7 +25,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/osx_64_mpiopenmpinumpy1.22python3.10.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_64_mpiopenmpinumpy1.22python3.10.____cpythonscalarreal.yaml
@@ -25,7 +25,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/osx_64_mpiopenmpinumpy1.22python3.8.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_64_mpiopenmpinumpy1.22python3.8.____cpythonscalarcomplex.yaml
@@ -25,7 +25,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/osx_64_mpiopenmpinumpy1.22python3.8.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_64_mpiopenmpinumpy1.22python3.8.____cpythonscalarreal.yaml
@@ -25,7 +25,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/osx_64_mpiopenmpinumpy1.22python3.9.____73_pypyscalarcomplex.yaml
+++ b/.ci_support/osx_64_mpiopenmpinumpy1.22python3.9.____73_pypyscalarcomplex.yaml
@@ -25,7 +25,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/osx_64_mpiopenmpinumpy1.22python3.9.____73_pypyscalarreal.yaml
+++ b/.ci_support/osx_64_mpiopenmpinumpy1.22python3.9.____73_pypyscalarreal.yaml
@@ -25,7 +25,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/osx_64_mpiopenmpinumpy1.22python3.9.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_64_mpiopenmpinumpy1.22python3.9.____cpythonscalarcomplex.yaml
@@ -25,7 +25,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/osx_64_mpiopenmpinumpy1.22python3.9.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_64_mpiopenmpinumpy1.22python3.9.____cpythonscalarreal.yaml
@@ -25,7 +25,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/osx_64_mpiopenmpinumpy1.23python3.11.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_64_mpiopenmpinumpy1.23python3.11.____cpythonscalarcomplex.yaml
@@ -25,7 +25,7 @@ mpich:
 numpy:
 - '1.23'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/osx_64_mpiopenmpinumpy1.23python3.11.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_64_mpiopenmpinumpy1.23python3.11.____cpythonscalarreal.yaml
@@ -25,7 +25,7 @@ mpich:
 numpy:
 - '1.23'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/osx_64_mpiopenmpinumpy1.26python3.12.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_64_mpiopenmpinumpy1.26python3.12.____cpythonscalarcomplex.yaml
@@ -25,7 +25,7 @@ mpich:
 numpy:
 - '1.26'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/osx_64_mpiopenmpinumpy1.26python3.12.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_64_mpiopenmpinumpy1.26python3.12.____cpythonscalarreal.yaml
@@ -25,7 +25,7 @@ mpich:
 numpy:
 - '1.26'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/osx_arm64_mpimpichnumpy1.22python3.10.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_arm64_mpimpichnumpy1.22python3.10.____cpythonscalarcomplex.yaml
@@ -25,7 +25,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/osx_arm64_mpimpichnumpy1.22python3.10.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_arm64_mpimpichnumpy1.22python3.10.____cpythonscalarreal.yaml
@@ -25,7 +25,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/osx_arm64_mpimpichnumpy1.22python3.8.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_arm64_mpimpichnumpy1.22python3.8.____cpythonscalarcomplex.yaml
@@ -25,7 +25,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/osx_arm64_mpimpichnumpy1.22python3.8.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_arm64_mpimpichnumpy1.22python3.8.____cpythonscalarreal.yaml
@@ -25,7 +25,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/osx_arm64_mpimpichnumpy1.22python3.9.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_arm64_mpimpichnumpy1.22python3.9.____cpythonscalarcomplex.yaml
@@ -25,7 +25,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/osx_arm64_mpimpichnumpy1.22python3.9.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_arm64_mpimpichnumpy1.22python3.9.____cpythonscalarreal.yaml
@@ -25,7 +25,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/osx_arm64_mpimpichnumpy1.23python3.11.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_arm64_mpimpichnumpy1.23python3.11.____cpythonscalarcomplex.yaml
@@ -25,7 +25,7 @@ mpich:
 numpy:
 - '1.23'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/osx_arm64_mpimpichnumpy1.23python3.11.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_arm64_mpimpichnumpy1.23python3.11.____cpythonscalarreal.yaml
@@ -25,7 +25,7 @@ mpich:
 numpy:
 - '1.23'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/osx_arm64_mpimpichnumpy1.26python3.12.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_arm64_mpimpichnumpy1.26python3.12.____cpythonscalarcomplex.yaml
@@ -25,7 +25,7 @@ mpich:
 numpy:
 - '1.26'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/osx_arm64_mpimpichnumpy1.26python3.12.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_arm64_mpimpichnumpy1.26python3.12.____cpythonscalarreal.yaml
@@ -25,7 +25,7 @@ mpich:
 numpy:
 - '1.26'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/osx_arm64_mpiopenmpinumpy1.22python3.10.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpinumpy1.22python3.10.____cpythonscalarcomplex.yaml
@@ -25,7 +25,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/osx_arm64_mpiopenmpinumpy1.22python3.10.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpinumpy1.22python3.10.____cpythonscalarreal.yaml
@@ -25,7 +25,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/osx_arm64_mpiopenmpinumpy1.22python3.8.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpinumpy1.22python3.8.____cpythonscalarcomplex.yaml
@@ -25,7 +25,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/osx_arm64_mpiopenmpinumpy1.22python3.8.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpinumpy1.22python3.8.____cpythonscalarreal.yaml
@@ -25,7 +25,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/osx_arm64_mpiopenmpinumpy1.22python3.9.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpinumpy1.22python3.9.____cpythonscalarcomplex.yaml
@@ -25,7 +25,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/osx_arm64_mpiopenmpinumpy1.22python3.9.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpinumpy1.22python3.9.____cpythonscalarreal.yaml
@@ -25,7 +25,7 @@ mpich:
 numpy:
 - '1.22'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/osx_arm64_mpiopenmpinumpy1.23python3.11.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpinumpy1.23python3.11.____cpythonscalarcomplex.yaml
@@ -25,7 +25,7 @@ mpich:
 numpy:
 - '1.23'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/osx_arm64_mpiopenmpinumpy1.23python3.11.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpinumpy1.23python3.11.____cpythonscalarreal.yaml
@@ -25,7 +25,7 @@ mpich:
 numpy:
 - '1.23'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/osx_arm64_mpiopenmpinumpy1.26python3.12.____cpythonscalarcomplex.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpinumpy1.26python3.12.____cpythonscalarcomplex.yaml
@@ -25,7 +25,7 @@ mpich:
 numpy:
 - '1.26'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.ci_support/osx_arm64_mpiopenmpinumpy1.26python3.12.____cpythonscalarreal.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpinumpy1.26python3.12.____cpythonscalarreal.yaml
@@ -25,7 +25,7 @@ mpich:
 numpy:
 - '1.26'
 openmpi:
-- '4'
+- '5'
 petsc4py:
 - '3.21'
 pin_run_as_build:

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -72,6 +72,13 @@ else
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \
         --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml" \
         --extra-meta flow_run_id="${flow_run_id:-}" remote_url="${remote_url:-}" sha="${sha:-}"
+
+    ( startgroup "Inspecting artifacts" ) 2> /dev/null
+
+    # inspect_artifacts was only added in conda-forge-ci-setup 4.6.0
+    command -v inspect_artifacts >/dev/null 2>&1 && inspect_artifacts || echo "inspect_artifacts needs conda-forge-ci-setup >=4.6.0"
+
+    ( endgroup "Inspecting artifacts" ) 2> /dev/null
     ( startgroup "Validating outputs" ) 2> /dev/null
 
     validate_recipe_outputs "${FEEDSTOCK_NAME}"

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -85,6 +85,13 @@ else
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \
         --clobber-file ./.ci_support/clobber_${CONFIG}.yaml \
         --extra-meta flow_run_id="$flow_run_id" remote_url="$remote_url" sha="$sha"
+
+    ( startgroup "Inspecting artifacts" ) 2> /dev/null
+
+    # inspect_artifacts was only added in conda-forge-ci-setup 4.6.0
+    command -v inspect_artifacts >/dev/null 2>&1 && inspect_artifacts || echo "inspect_artifacts needs conda-forge-ci-setup >=4.6.0"
+
+    ( endgroup "Inspecting artifacts" ) 2> /dev/null
     ( startgroup "Validating outputs" ) 2> /dev/null
 
     validate_recipe_outputs "${FEEDSTOCK_NAME}"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "slepc4py" %}
 {% set version = "3.21.1" %}
 {% set sha256 = "bc8e0e270643eef9b63b249080b8fe4433be0b697d55032d9f768ef310bd7b07" %}
-{% set build = 101 %}
+{% set build = 102 %}
 
 {% set version_xy = version.rsplit('.', 1)[0] %}
 


### PR DESCRIPTION
I don't think we are going to get bot PRs to this and petsc4py because rerender takes half an hour on my laptop, which tends to be about twice as fast as the bot rerenders on CI.